### PR TITLE
Inject overlay canvas after DOM content loaded

### DIFF
--- a/wplace-overlay/content.js
+++ b/wplace-overlay/content.js
@@ -1,2 +1,16 @@
 // Content script for Wplace Overlay
-console.log('Wplace Overlay activated');
+document.addEventListener('DOMContentLoaded', () => {
+  console.log('Wplace Overlay activated');
+
+  const canvas = document.querySelector('canvas');
+  const mapContainer = canvas?.parentElement || document.body;
+
+  const overlay = document.createElement('canvas');
+  overlay.style.position = 'absolute';
+  overlay.style.top = '0';
+  overlay.style.left = '0';
+  overlay.style.pointerEvents = 'none';
+
+  mapContainer.style.position = 'relative';
+  mapContainer.appendChild(overlay);
+});


### PR DESCRIPTION
## Summary
- wait for DOMContentLoaded before activating overlay script
- insert absolute-positioned canvas overlay into map container with pointer-events: none

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897a3ff4df883309ec7567083f947a9