### PR TITLE
Add image overlay file input control panel

### DIFF
--- a/wplace-overlay/content.js
+++ b/wplace-overlay/content.js
@@ -13,4 +13,36 @@ document.addEventListener('DOMContentLoaded', () => {
 
   mapContainer.style.position = 'relative';
   mapContainer.appendChild(overlay);
+
+  // Create a simple control panel
+  const controlPanel = document.createElement('div');
+  controlPanel.className = 'control-panel';
+
+  const fileInput = document.createElement('input');
+  fileInput.type = 'file';
+  fileInput.accept = 'image/*';
+
+  // Handle image loading and drawing
+  fileInput.addEventListener('change', (event) => {
+    const file = event.target.files && event.target.files[0];
+    if (!file) return;
+
+    const url = URL.createObjectURL(file);
+    const img = new Image();
+
+    img.onload = () => {
+      overlay.width = canvas.width;
+      overlay.height = canvas.height;
+      const ctx = overlay.getContext('2d');
+      if (!ctx) return;
+      ctx.clearRect(0, 0, overlay.width, overlay.height);
+      ctx.drawImage(img, 0, 0, overlay.width, overlay.height);
+      URL.revokeObjectURL(url);
+    };
+
+    img.src = url;
+  });
+
+  controlPanel.appendChild(fileInput);
+  mapContainer.appendChild(controlPanel);
 });

--- a/wplace-overlay/styles.css
+++ b/wplace-overlay/styles.css
@@ -2,3 +2,13 @@
 body {
   background: rgba(0, 0, 0, 0.1);
 }
+
+/* Control panel styling */
+.control-panel {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  background: rgba(255, 255, 255, 0.8);
+  padding: 5px;
+  z-index: 1000;
+}


### PR DESCRIPTION
## Summary
- add control panel with file input to load image using `URL.createObjectURL`
- render uploaded image onto overlay canvas and style the control panel

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6897a4ef9e2c8330b873905e8d0c2ff7