### PR TITLE
feat: add draggable image overlay with transform controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "wplace-extension",
+  "version": "1.0.0",
+  "description": "Wplace-extension est un projet qui consiste à fournir une extension permettant de mettre un layer sur la carte de wplace afin de la reproduire sur le site",
+  "scripts": {
+    "test": "node tests/transform.test.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/tests/transform.test.js
+++ b/tests/transform.test.js
@@ -1,0 +1,26 @@
+const assert = require('assert');
+const { applyTransform } = require('../wplace-overlay/transform.js');
+
+function mockCtx() {
+  let args = null;
+  return {
+    setTransform: (...a) => {
+      args = a;
+    },
+    getArgs: () => args
+  };
+}
+
+const ctx = mockCtx();
+const state = { scale: 2, rotation: Math.PI / 2, x: 10, y: -5 };
+applyTransform(ctx, state);
+const args = ctx.getArgs();
+assert(args, 'setTransform should be called');
+assert(Math.abs(args[0] - 0) < 1e-10, 'a component');
+assert(Math.abs(args[1] - 2) < 1e-10, 'b component');
+assert(Math.abs(args[2] + 2) < 1e-10, 'c component');
+assert(Math.abs(args[3] - 0) < 1e-10, 'd component');
+assert.strictEqual(args[4], 10, 'e component');
+assert.strictEqual(args[5], -5, 'f component');
+
+console.log('transform.test.js passed');

--- a/wplace-overlay/content.js
+++ b/wplace-overlay/content.js
@@ -1,48 +1,151 @@
 // Content script for Wplace Overlay
-document.addEventListener('DOMContentLoaded', () => {
-  console.log('Wplace Overlay activated');
+if (typeof window !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', () => {
+    console.log('Wplace Overlay activated');
 
-  const canvas = document.querySelector('canvas');
-  const mapContainer = canvas?.parentElement || document.body;
+    const canvas = document.querySelector('canvas');
+    const mapContainer = canvas?.parentElement || document.body;
 
-  const overlay = document.createElement('canvas');
-  overlay.style.position = 'absolute';
-  overlay.style.top = '0';
-  overlay.style.left = '0';
-  overlay.style.pointerEvents = 'none';
+    const overlay = document.createElement('canvas');
+    overlay.style.position = 'absolute';
+    overlay.style.top = '0';
+    overlay.style.left = '0';
+    overlay.style.pointerEvents = 'auto';
+    overlay.style.cursor = 'move';
 
-  mapContainer.style.position = 'relative';
-  mapContainer.appendChild(overlay);
+    mapContainer.style.position = 'relative';
+    mapContainer.appendChild(overlay);
 
-  // Create a simple control panel
-  const controlPanel = document.createElement('div');
-  controlPanel.className = 'control-panel';
+    const ctx = overlay.getContext('2d');
+    let img = null;
+    const state = { x: 0, y: 0, scale: 1, rotation: 0 };
 
-  const fileInput = document.createElement('input');
-  fileInput.type = 'file';
-  fileInput.accept = 'image/*';
-
-  // Handle image loading and drawing
-  fileInput.addEventListener('change', (event) => {
-    const file = event.target.files && event.target.files[0];
-    if (!file) return;
-
-    const url = URL.createObjectURL(file);
-    const img = new Image();
-
-    img.onload = () => {
-      overlay.width = canvas.width;
-      overlay.height = canvas.height;
-      const ctx = overlay.getContext('2d');
-      if (!ctx) return;
+    function draw() {
+      if (!ctx || !img) return;
       ctx.clearRect(0, 0, overlay.width, overlay.height);
+      applyTransform(ctx, state);
       ctx.drawImage(img, 0, 0, overlay.width, overlay.height);
-      URL.revokeObjectURL(url);
-    };
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
+    }
 
-    img.src = url;
+    // Drag and drop to move image
+    let isDragging = false;
+    let lastX = 0;
+    let lastY = 0;
+    overlay.addEventListener('pointerdown', (e) => {
+      isDragging = true;
+      lastX = e.clientX;
+      lastY = e.clientY;
+      overlay.setPointerCapture(e.pointerId);
+    });
+    overlay.addEventListener('pointermove', (e) => {
+      if (!isDragging) return;
+      const dx = e.clientX - lastX;
+      const dy = e.clientY - lastY;
+      state.x += dx;
+      state.y += dy;
+      lastX = e.clientX;
+      lastY = e.clientY;
+      draw();
+    });
+    overlay.addEventListener('pointerup', (e) => {
+      isDragging = false;
+      overlay.releasePointerCapture(e.pointerId);
+    });
+    overlay.addEventListener('pointerleave', () => {
+      isDragging = false;
+    });
+
+    // Create control panel
+    const controlPanel = document.createElement('div');
+    controlPanel.className = 'control-panel';
+
+    const fileInput = document.createElement('input');
+    fileInput.type = 'file';
+    fileInput.accept = 'image/*';
+
+    const scaleSlider = document.createElement('input');
+    scaleSlider.type = 'range';
+    scaleSlider.min = '0.1';
+    scaleSlider.max = '5';
+    scaleSlider.step = '0.1';
+    scaleSlider.value = '1';
+
+    const rotationSlider = document.createElement('input');
+    rotationSlider.type = 'range';
+    rotationSlider.min = '-180';
+    rotationSlider.max = '180';
+    rotationSlider.step = '1';
+    rotationSlider.value = '0';
+
+    scaleSlider.addEventListener('input', () => {
+      state.scale = parseFloat(scaleSlider.value);
+      draw();
+    });
+
+    rotationSlider.addEventListener('input', () => {
+      state.rotation = (parseFloat(rotationSlider.value) * Math.PI) / 180;
+      draw();
+    });
+
+    // Keyboard shortcuts
+    document.addEventListener('keydown', (e) => {
+      switch (e.key) {
+        case '+':
+        case '=':
+          state.scale = Math.min(state.scale + 0.1, 5);
+          scaleSlider.value = state.scale.toFixed(1);
+          draw();
+          break;
+        case '-':
+        case '_':
+          state.scale = Math.max(state.scale - 0.1, 0.1);
+          scaleSlider.value = state.scale.toFixed(1);
+          draw();
+          break;
+        case '[':
+          state.rotation -= (5 * Math.PI) / 180;
+          rotationSlider.value = (state.rotation * 180) / Math.PI;
+          draw();
+          break;
+        case ']':
+          state.rotation += (5 * Math.PI) / 180;
+          rotationSlider.value = (state.rotation * 180) / Math.PI;
+          draw();
+          break;
+        default:
+          return;
+      }
+    });
+
+    // Handle image loading
+    fileInput.addEventListener('change', (event) => {
+      const file = event.target.files && event.target.files[0];
+      if (!file) return;
+
+      const url = URL.createObjectURL(file);
+      const image = new Image();
+
+      image.onload = () => {
+        img = image;
+        overlay.width = canvas?.width || img.width;
+        overlay.height = canvas?.height || img.height;
+        state.x = 0;
+        state.y = 0;
+        state.scale = 1;
+        state.rotation = 0;
+        scaleSlider.value = '1';
+        rotationSlider.value = '0';
+        draw();
+        URL.revokeObjectURL(url);
+      };
+
+      image.src = url;
+    });
+
+    controlPanel.appendChild(fileInput);
+    controlPanel.appendChild(scaleSlider);
+    controlPanel.appendChild(rotationSlider);
+    mapContainer.appendChild(controlPanel);
   });
-
-  controlPanel.appendChild(fileInput);
-  mapContainer.appendChild(controlPanel);
-});
+}

--- a/wplace-overlay/manifest.json
+++ b/wplace-overlay/manifest.json
@@ -9,7 +9,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["content.js"],
+      "js": ["transform.js", "content.js"],
       "css": ["styles.css"]
     }
   ]

--- a/wplace-overlay/transform.js
+++ b/wplace-overlay/transform.js
@@ -1,0 +1,14 @@
+(function (global) {
+  function applyTransform(ctx, state) {
+    const { scale = 1, rotation = 0, x = 0, y = 0 } = state || {};
+    const cos = Math.cos(rotation) * scale;
+    const sin = Math.sin(rotation) * scale;
+    ctx.setTransform(cos, sin, -sin, cos, x, y);
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { applyTransform };
+  } else {
+    global.applyTransform = applyTransform;
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : this);


### PR DESCRIPTION
## Summary
- allow overlay image to be moved with pointer drag
- add scale and rotation sliders plus keyboard shortcuts
- centralize canvas transformations in helper and cover with unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897a7a6d83c8330a7b2500a747b3d5c