### PR TITLE
feat: add overlay controls and persistence

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Wplace-extension est un projet qui consiste à fournir une extension permettant de mettre un layer sur la carte de wplace afin de la reproduire sur le site",
   "scripts": {
-    "test": "node tests/transform.test.js"
+    "test": "node tests/transform.test.js && node tests/storage.test.js"
   },
   "keywords": [],
   "author": "",

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -1,0 +1,44 @@
+const assert = require('assert');
+const { saveOverlayState, loadOverlayState } = require('../wplace-overlay/storage.js');
+
+function createMockChrome() {
+  const store = {};
+  return {
+    storage: {
+      local: {
+        set: (data, cb) => {
+          Object.assign(store, data);
+          if (cb) cb();
+        },
+        get: (key, cb) => {
+          if (typeof key === 'string') {
+            cb({ [key]: store[key] });
+          } else {
+            cb(store);
+          }
+        }
+      }
+    },
+    runtime: {
+      lastError: null
+    }
+  };
+}
+
+global.chrome = createMockChrome();
+
+(async () => {
+  const state = {
+    mapX: 1,
+    mapY: 2,
+    scale: 1.5,
+    rotation: 0.5,
+    opacity: 0.8,
+    active: true,
+    imageSrc: 'data:image/png;base64,abc'
+  };
+  await saveOverlayState(state);
+  const loaded = await loadOverlayState();
+  assert.deepStrictEqual(loaded, state);
+  console.log('storage.test.js passed');
+})();

--- a/wplace-overlay/manifest.json
+++ b/wplace-overlay/manifest.json
@@ -9,7 +9,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["transform.js", "content.js"],
+      "js": ["transform.js", "storage.js", "content.js"],
       "css": ["styles.css"]
     }
   ]

--- a/wplace-overlay/storage.js
+++ b/wplace-overlay/storage.js
@@ -1,0 +1,34 @@
+(function (global) {
+  function saveOverlayState(state) {
+    return new Promise((resolve, reject) => {
+      if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.local) {
+        chrome.storage.local.set({ overlayState: state }, () => {
+          const err = chrome.runtime && chrome.runtime.lastError;
+          if (err) reject(err);
+          else resolve();
+        });
+      } else {
+        resolve();
+      }
+    });
+  }
+
+  function loadOverlayState() {
+    return new Promise((resolve) => {
+      if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.local) {
+        chrome.storage.local.get('overlayState', (result) => {
+          resolve(result.overlayState || {});
+        });
+      } else {
+        resolve({});
+      }
+    });
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { saveOverlayState, loadOverlayState };
+  } else {
+    global.saveOverlayState = saveOverlayState;
+    global.loadOverlayState = loadOverlayState;
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : this);


### PR DESCRIPTION
## Summary
- add floating overlay control panel with x/y position, scale, rotation and opacity controls
- persist overlay state with chrome.storage and allow toggling visibility
- cover storage helpers with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897adc1182083309aac01ba98a4b559