### PR TITLE
Fix overlay initialization and control panel placement

### DIFF
--- a/wplace-overlay/content.js
+++ b/wplace-overlay/content.js
@@ -1,6 +1,6 @@
 // Content script for Wplace Overlay
 if (typeof window !== 'undefined') {
-  document.addEventListener('DOMContentLoaded', () => {
+  function init() {
     console.log('Wplace Overlay activated');
 
     const canvas = document.querySelector('canvas');
@@ -325,7 +325,7 @@ if (typeof window !== 'undefined') {
     controlsContainer.appendChild(opacitySlider);
     controlsContainer.appendChild(exportButton);
     controlsContainer.appendChild(importInput);
-    mapContainer.appendChild(controlPanel);
+    document.body.appendChild(controlPanel);
 
     loadOverlayState().then((saved) => {
       Object.assign(state, saved);
@@ -353,5 +353,11 @@ if (typeof window !== 'undefined') {
         updateOverlay();
       }
     });
-  });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
 }

--- a/wplace-overlay/popup.html
+++ b/wplace-overlay/popup.html
@@ -7,6 +7,6 @@
 </head>
 <body>
   <h1>Wplace Overlay</h1>
-  <script src="content.js"></script>
+  <p>L'overlay est actif sur la page ouverte.</p>
 </body>
 </html>

--- a/wplace-overlay/styles.css
+++ b/wplace-overlay/styles.css
@@ -5,7 +5,7 @@ body {
 
 /* Control panel styling */
 .control-panel {
-  position: absolute;
+  position: fixed;
   top: 10px;
   left: 10px;
   background: rgba(255, 255, 255, 0.8);


### PR DESCRIPTION
## Summary
- Ensure content script initializes after installation or page load
- Attach control panel to document body with fixed positioning
- Clarify popup messaging and remove redundant script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897dd9973188330a91308901e8649c4